### PR TITLE
Provide additional documentation of rest endpoints

### DIFF
--- a/src/main/kotlin/dev/synek/puckmetrics/features/games/GamesController.kt
+++ b/src/main/kotlin/dev/synek/puckmetrics/features/games/GamesController.kt
@@ -4,6 +4,9 @@ import dev.synek.puckmetrics.contracts.CreateGameRequest
 import dev.synek.puckmetrics.contracts.GameDetailsResponse
 import dev.synek.puckmetrics.contracts.GameInfoResponse
 import dev.synek.puckmetrics.shared.ControllerConstants.APPLICATION_JSON
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Pageable
@@ -16,6 +19,15 @@ import java.net.URI
 class GamesController(
     @Autowired private val gamesService: GamesService,
 ) {
+    @Operation(
+        summary = "List all games",
+        description = "Lists all games in the system."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Games were successfully retrieved.")
+        ]
+    )
     @GetMapping(GamesEndpointURLs.GET_ALL_GAMES)
     fun getAllGames(
         pageable: Pageable
@@ -27,6 +39,16 @@ class GamesController(
         return ResponseEntity.ok(games)
     }
 
+    @Operation(
+        summary = "Get game by ID",
+        description = "Retrieves a game by its ID."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Game was successfully retrieved."),
+            ApiResponse(responseCode = "404", description = "Game with the given ID was not found.")
+        ]
+    )
     @GetMapping(GamesEndpointURLs.GET_GAME_BY_ID)
     fun getGameById(
         @PathVariable id: Long
@@ -37,6 +59,16 @@ class GamesController(
         return ResponseEntity.ok(game.toDetailsResponse())
     }
 
+    @Operation(
+        summary = "Create a game",
+        description = "Creates a new game."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "Game was successfully created."),
+            ApiResponse(responseCode = "400", description = "Invalid request body.")
+        ]
+    )
     @PostMapping(
         GamesEndpointURLs.CREATE_GAME,
         consumes = [APPLICATION_JSON],
@@ -57,6 +89,16 @@ class GamesController(
             .body(game.toDetailsResponse())
     }
 
+    @Operation(
+        summary = "Delete a game",
+        description = "Deletes a game."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "Game was successfully deleted."),
+            ApiResponse(responseCode = "404", description = "Game with the given ID was not found.")
+        ]
+    )
     @DeleteMapping(GamesEndpointURLs.DELETE_GAME)
     fun deleteGame(
         @PathVariable id: Long

--- a/src/main/kotlin/dev/synek/puckmetrics/features/players/PlayersController.kt
+++ b/src/main/kotlin/dev/synek/puckmetrics/features/players/PlayersController.kt
@@ -4,6 +4,9 @@ import dev.synek.puckmetrics.contracts.CreateUpdatePlayerRequest
 import dev.synek.puckmetrics.contracts.PlayerDetailsResponse
 import dev.synek.puckmetrics.contracts.PlayerInfoResponse
 import dev.synek.puckmetrics.shared.ControllerConstants.APPLICATION_JSON
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
@@ -14,6 +17,15 @@ import org.springframework.web.bind.annotation.*
 class PlayersController(
     private val playersService: PlayersService
 ) {
+    @Operation(
+        summary = "List all players",
+        description = "Lists all players in the system."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Players were successfully retrieved.")
+        ]
+    )
     @GetMapping(PlayersEndpointURLs.GET_ALL_PLAYERS, produces = [APPLICATION_JSON])
     fun getAllPlayers(
         pageable: Pageable,
@@ -25,6 +37,16 @@ class PlayersController(
         return ResponseEntity.ok(players)
     }
 
+    @Operation(
+        summary = "Get player by ID",
+        description = "Retrieves a player by its ID."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Player was successfully retrieved."),
+            ApiResponse(responseCode = "404", description = "Player with the given ID was not found.")
+        ]
+    )
     @GetMapping(PlayersEndpointURLs.GET_PLAYER_BY_ID, produces = [APPLICATION_JSON])
     fun getPlayerById(
         @PathVariable id: Long,
@@ -35,6 +57,16 @@ class PlayersController(
         return ResponseEntity.ok(player.toDetailsResponse())
     }
 
+    @Operation(
+        summary = "Create a player",
+        description = "Creates a new player."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Player was successfully created."),
+            ApiResponse(responseCode = "400", description = "Invalid request body.")
+        ]
+    )
     @PostMapping(
         PlayersEndpointURLs.CREATE_PLAYER,
         consumes = [APPLICATION_JSON],
@@ -48,6 +80,17 @@ class PlayersController(
         return ResponseEntity.ok(player.toDetailsResponse())
     }
 
+    @Operation(
+        summary = "Update a player",
+        description = "Updates a player."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "202", description = "Player was successfully updated."),
+            ApiResponse(responseCode = "400", description = "Invalid request body."),
+            ApiResponse(responseCode = "404", description = "Player with the given ID was not found.")
+        ]
+    )
     @PutMapping(
         PlayersEndpointURLs.UPDATE_PLAYER,
         consumes = [APPLICATION_JSON],
@@ -65,6 +108,16 @@ class PlayersController(
         return ResponseEntity.accepted().body(updatedPlayer.toDetailsResponse())
     }
 
+    @Operation(
+        summary = "Delete a player",
+        description = "Deletes a player."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "Player was successfully deleted."),
+            ApiResponse(responseCode = "404", description = "Player with the given ID was not found.")
+        ]
+    )
     @DeleteMapping(PlayersEndpointURLs.DELETE_PLAYER)
     fun deletePlayer(
         @PathVariable id: Long,

--- a/src/main/kotlin/dev/synek/puckmetrics/features/stats/StatsController.kt
+++ b/src/main/kotlin/dev/synek/puckmetrics/features/stats/StatsController.kt
@@ -2,6 +2,9 @@ package dev.synek.puckmetrics.features.stats
 
 import dev.synek.puckmetrics.contracts.*
 import dev.synek.puckmetrics.shared.ControllerConstants.APPLICATION_JSON
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -12,6 +15,15 @@ import org.springframework.web.bind.annotation.RestController
 class StatsController(
     @Autowired private val statsService: StatsService,
 ) {
+    @Operation(
+        summary = "List best coaches",
+        description = "List best coach in each season measured by number of games won."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Best coaches were successfully retrieved.")
+        ]
+    )
     @GetMapping(
         StatsEndpointURLs.GET_TOP_COACHES,
         produces = [APPLICATION_JSON]
@@ -19,7 +31,15 @@ class StatsController(
     fun getBestCoaches(): List<BestCoachInSeasonResponse> =
         statsService.getBestCoaches()
 
-
+    @Operation(
+        summary = "List top goal scorers",
+        description = "List top goal scorers in each season measured by number of goals scored."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Top goal scorers were successfully retrieved.")
+        ]
+    )
     @GetMapping(
         StatsEndpointURLs.GET_TOP_GOAL_SCORERS,
         produces = [APPLICATION_JSON]
@@ -28,6 +48,15 @@ class StatsController(
         statsService.getTopGoalScorers()
 
 
+    @Operation(
+        summary = "List top assisters",
+        description = "List top assisters in each season measured by number of assists."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Top assisters were successfully retrieved.")
+        ]
+    )
     @GetMapping(
         StatsEndpointURLs.GET_TOP_ASSISTERS,
         produces = [APPLICATION_JSON]
@@ -35,6 +64,15 @@ class StatsController(
     fun getTopAssisters(): List<PlayerSeasonAssistsResponse> =
         statsService.getTopAssisters()
 
+    @Operation(
+        summary = "List top point scorers",
+        description = "List top point scorers in each season measured by number of points (goals + assists)."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Top point scorers were successfully retrieved.")
+        ]
+    )
     @GetMapping(
         StatsEndpointURLs.GET_TOP_POINT_SCORERS,
         produces = [APPLICATION_JSON]
@@ -42,6 +80,15 @@ class StatsController(
     fun getTopPoints(): List<PlayerSeasonPointsResponse> =
         statsService.getTopPointScorers()
 
+    @Operation(
+        summary = "List top face-off takers",
+        description = "List top face-off takers in each season measured by percentage of face-offs won."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Top face-off takers were successfully retrieved.")
+        ]
+    )
     @GetMapping(
         StatsEndpointURLs.GET_TOP_FACE_OFF_TAKERS,
         produces = [APPLICATION_JSON]

--- a/src/main/kotlin/dev/synek/puckmetrics/features/teams/TeamsController.kt
+++ b/src/main/kotlin/dev/synek/puckmetrics/features/teams/TeamsController.kt
@@ -3,6 +3,9 @@ package dev.synek.puckmetrics.features.teams
 import dev.synek.puckmetrics.contracts.CreateUpdateTeamRequest
 import dev.synek.puckmetrics.contracts.TeamInfoResponse
 import dev.synek.puckmetrics.shared.ControllerConstants.APPLICATION_JSON
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
@@ -14,6 +17,12 @@ import java.net.URI
 class TeamsController(
     private val teamsService: TeamsService,
 ) {
+    @Operation(summary = "List all teams", description = "Lists all teams in the system.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Teams were successfully retrieved.")
+        ]
+    )
     @GetMapping(TeamsEndpointURLs.GET_ALL_TEAMS, produces = [APPLICATION_JSON])
     fun getAllTeams(
         pageable: Pageable

--- a/src/main/kotlin/dev/synek/puckmetrics/features/teams/TeamsController.kt
+++ b/src/main/kotlin/dev/synek/puckmetrics/features/teams/TeamsController.kt
@@ -34,6 +34,13 @@ class TeamsController(
         return ResponseEntity.ok(teams)
     }
 
+    @Operation(summary = "Get team by ID", description = "Retrieves a team by its ID.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Team was successfully retrieved."),
+            ApiResponse(responseCode = "404", description = "Team with the given ID was not found.")
+        ]
+    )
     @GetMapping(TeamsEndpointURLs.GET_TEAM_BY_ID, produces = [APPLICATION_JSON])
     fun getTeamById(@PathVariable id: Long): ResponseEntity<TeamInfoResponse> {
         val team = teamsService.get(id)?.toResponse()
@@ -42,6 +49,13 @@ class TeamsController(
         return ResponseEntity.ok(team)
     }
 
+    @Operation(summary = "Create a team", description = "Creates a new team.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "Team was successfully created."),
+            ApiResponse(responseCode = "400", description = "Invalid request body.")
+        ]
+    )
     @PostMapping(
         TeamsEndpointURLs.CREATE_TEAM,
         consumes = [APPLICATION_JSON],
@@ -58,6 +72,14 @@ class TeamsController(
         return ResponseEntity.created(URI.create("/teams/${createdTeam.id}")).body(createdTeam.toResponse())
     }
 
+    @Operation(summary = "Update a team", description = "Updates a team.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "202", description = "Team was successfully updated."),
+            ApiResponse(responseCode = "400", description = "Invalid request body."),
+            ApiResponse(responseCode = "404", description = "Team with the given ID was not found.")
+        ]
+    )
     @PutMapping(
         TeamsEndpointURLs.UPDATE_TEAM,
         consumes = [APPLICATION_JSON],
@@ -78,7 +100,17 @@ class TeamsController(
             .body(updatedTeam.toResponse())
     }
 
-    @DeleteMapping(TeamsEndpointURLs.DELETE_TEAM)
+    @Operation(summary = "Delete a team", description = "Deletes a team.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "Team was successfully deleted."),
+            ApiResponse(responseCode = "404", description = "Team with the given ID was not found.")
+        ]
+    )
+    @DeleteMapping(
+        TeamsEndpointURLs.DELETE_TEAM,
+        produces = [APPLICATION_JSON],
+    )
     fun deleteTeam(@PathVariable id: Long): ResponseEntity<Unit> {
         val isDeleted = teamsService.delete(id)
 


### PR DESCRIPTION
Adds attributes to REST endpoints to provide more endpoint documentation via OpenAPI (rendered in Swagger UI)

# Endpoints
- [x] `TeamsController`
- [x] `StatsController`
- [x] `PlayersController`
- [x] `GamesController`